### PR TITLE
Step 9

### DIFF
--- a/src/main/generated/kr/jsh/ecommerce/domain/fruit/QFruit.java
+++ b/src/main/generated/kr/jsh/ecommerce/domain/fruit/QFruit.java
@@ -20,11 +20,6 @@ public class QFruit extends EntityPathBase<Fruit> {
 
     public static final QFruit fruit = new QFruit("fruit");
 
-    public final kr.jsh.ecommerce.base.entity.QBaseEntity _super = new kr.jsh.ecommerce.base.entity.QBaseEntity(this);
-
-    //inherited
-    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
-
     public final NumberPath<Long> fruitId = createNumber("fruitId", Long.class);
 
     public final StringPath fruitName = createString("fruitName");
@@ -36,9 +31,6 @@ public class QFruit extends EntityPathBase<Fruit> {
     public final ListPath<kr.jsh.ecommerce.domain.order.OrderFruit, kr.jsh.ecommerce.domain.order.QOrderFruit> orderFruits = this.<kr.jsh.ecommerce.domain.order.OrderFruit, kr.jsh.ecommerce.domain.order.QOrderFruit>createList("orderFruits", kr.jsh.ecommerce.domain.order.OrderFruit.class, kr.jsh.ecommerce.domain.order.QOrderFruit.class, PathInits.DIRECT2);
 
     public final StringPath status = createString("status");
-
-    //inherited
-    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 
     public QFruit(String variable) {
         super(Fruit.class, forVariable(variable));

--- a/src/main/java/kr/jsh/ecommerce/ServerApplication.java
+++ b/src/main/java/kr/jsh/ecommerce/ServerApplication.java
@@ -2,8 +2,10 @@ package kr.jsh.ecommerce;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication(scanBasePackages = "kr.jsh.ecommerce")
+@SpringBootApplication
+@EnableJpaRepositories(basePackages = "kr.jsh.ecommerce.infrastructure")
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/jsh/ecommerce/base/dto/response/BaseResponse.java
+++ b/src/main/java/kr/jsh/ecommerce/base/dto/response/BaseResponse.java
@@ -2,9 +2,13 @@ package kr.jsh.ecommerce.base.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import kr.jsh.ecommerce.base.dto.BaseErrorCode;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
+@Getter
+@Setter
 public class BaseResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     private LocalDateTime timestamp = LocalDateTime.now();

--- a/src/main/java/kr/jsh/ecommerce/base/exception/BaseControllerExceptionHandler.java
+++ b/src/main/java/kr/jsh/ecommerce/base/exception/BaseControllerExceptionHandler.java
@@ -1,0 +1,36 @@
+package kr.jsh.ecommerce.base.exception;
+
+import kr.jsh.ecommerce.base.dto.BaseErrorCode;
+import kr.jsh.ecommerce.base.dto.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class BaseControllerExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponse> handleException(Exception e) {
+
+        BaseErrorCode baseErrorCode = BaseErrorCode.INTERNAL_SERVER_ERROR;
+
+        BaseResponse baseResponse = new BaseResponse();
+        baseResponse.setMessage(baseErrorCode.getMessage());
+        baseResponse.setStatus(baseErrorCode.getHttpStatus().toString());
+
+        return new ResponseEntity<>(baseResponse, baseErrorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(BaseCustomException.class)
+    public ResponseEntity<BaseResponse> handleBaseCustomException(BaseCustomException e) {
+
+        BaseErrorCode baseErrorCode = e.getBaseErrorCode();
+
+        BaseResponse baseResponse = new BaseResponse();
+        baseResponse.setMessage(e.formatMessage());
+        baseResponse.setStatus(baseErrorCode.getHttpStatus().toString());
+
+        return new ResponseEntity<>(baseResponse, baseErrorCode.getHttpStatus());
+    }
+}

--- a/src/main/java/kr/jsh/ecommerce/base/exception/BaseCustomException.java
+++ b/src/main/java/kr/jsh/ecommerce/base/exception/BaseCustomException.java
@@ -1,9 +1,11 @@
 package kr.jsh.ecommerce.base.exception;
 
 import kr.jsh.ecommerce.base.dto.BaseErrorCode;
+import lombok.Getter;
 
 import java.text.MessageFormat;
 
+@Getter
 public class BaseCustomException extends RuntimeException {
     private final BaseErrorCode baseErrorCode;
     private String[] msgArgs;

--- a/src/main/java/kr/jsh/ecommerce/config/WebConfig.java
+++ b/src/main/java/kr/jsh/ecommerce/config/WebConfig.java
@@ -1,0 +1,21 @@
+package kr.jsh.ecommerce.config;
+
+import kr.jsh.ecommerce.config.interceptor.LoggingInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoggingInterceptor loggingInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor)
+                .addPathPatterns("/api/items/**");
+    }
+}
+

--- a/src/main/java/kr/jsh/ecommerce/config/interceptor/LoggingInterceptor.java
+++ b/src/main/java/kr/jsh/ecommerce/config/interceptor/LoggingInterceptor.java
@@ -1,0 +1,30 @@
+package kr.jsh.ecommerce.config.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+public class LoggingInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        log.info("Request URL: {}", request.getRequestURL());
+        log.info("HTTP Method: {}", request.getMethod());
+        log.info("Client IP: {}", request.getRemoteAddr());
+        log.info("Request Params: {}", request.getQueryString());
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        log.info("Response Status: {}", response.getStatus());
+        if (ex != null) {
+            log.error("Exception: ", ex);
+        }
+    }
+}
+

--- a/src/main/java/kr/jsh/ecommerce/domain/customer/Customer.java
+++ b/src/main/java/kr/jsh/ecommerce/domain/customer/Customer.java
@@ -26,8 +26,7 @@ public class Customer {
     @Column(nullable = false)
     private String customerPhone;
 
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "wallet_id")
+    @OneToOne(mappedBy = "customer")
     private Wallet wallet;
 
     public void setWallet(Wallet wallet) {

--- a/src/main/java/kr/jsh/ecommerce/domain/fruit/Fruit.java
+++ b/src/main/java/kr/jsh/ecommerce/domain/fruit/Fruit.java
@@ -15,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA용 기본 생성자
 @AllArgsConstructor(access = AccessLevel.PRIVATE) // Builder용 생성자
 @Table(name = "fruit")
-public class Fruit extends BaseEntity {
+public class Fruit{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long fruitId;

--- a/src/main/java/kr/jsh/ecommerce/domain/order/Order.java
+++ b/src/main/java/kr/jsh/ecommerce/domain/order/Order.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA용 기본 생성자
 @AllArgsConstructor(access = AccessLevel.PRIVATE) // Builder용 생성자
-@Table(name = "order")
+@Table(name = "`order`")
 public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/jsh/ecommerce/domain/wallet/Wallet.java
+++ b/src/main/java/kr/jsh/ecommerce/domain/wallet/Wallet.java
@@ -17,11 +17,16 @@ public class Wallet {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long walletId;
 
-    @OneToOne(mappedBy = "customer",cascade = CascadeType.ALL,orphanRemoval = true)
-    private Customer customer;
-
     @Column(nullable = false)
     private int balance;
+
+    @OneToOne
+    @JoinColumn(name = "customer_id", nullable = false)
+    private Customer customer;
+
+    public void setCustomer(Customer customer) {
+        this.customer = customer;
+    }
 
     public void spendCash(int amount){
         if(amount>this.balance){

--- a/src/main/java/kr/jsh/ecommerce/infrastructure/coupon/CouponIssueJpaRepository.java
+++ b/src/main/java/kr/jsh/ecommerce/infrastructure/coupon/CouponIssueJpaRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 
 public interface CouponIssueJpaRepository extends JpaRepository<CouponIssue,Long> {
     // 고객 ID로 발급된 쿠폰 목록 조회

--- a/src/main/java/kr/jsh/ecommerce/infrastructure/customer/CustomerJpaRepository.java
+++ b/src/main/java/kr/jsh/ecommerce/infrastructure/customer/CustomerJpaRepository.java
@@ -1,0 +1,7 @@
+package kr.jsh.ecommerce.infrastructure.customer;
+
+import kr.jsh.ecommerce.domain.customer.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerJpaRepository extends JpaRepository<Customer,Long>{
+}

--- a/src/main/java/kr/jsh/ecommerce/infrastructure/customer/CustomerRepositoryImpl.java
+++ b/src/main/java/kr/jsh/ecommerce/infrastructure/customer/CustomerRepositoryImpl.java
@@ -1,0 +1,24 @@
+package kr.jsh.ecommerce.infrastructure.customer;
+
+import kr.jsh.ecommerce.domain.customer.Customer;
+import kr.jsh.ecommerce.domain.customer.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomerRepositoryImpl implements CustomerRepository {
+    private final CustomerJpaRepository customerJpaRepository;
+
+    @Override
+    public Optional<Customer> findById(Long id) {
+        return customerJpaRepository.findById(id);
+    }
+
+    @Override
+    public Customer save(Customer customer) {
+        return customerJpaRepository.save(customer);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,4 +38,5 @@ spring:
 
 logging:
   level:
-    org.springframework.context.annotation: DEBUG
+    root:INFO
+    kr.jsh.ecommerce.config.interceptor:DEBUG

--- a/src/test/java/kr/jsh/ecommerce/application/fruit/GetFruitUseCaseTest.java
+++ b/src/test/java/kr/jsh/ecommerce/application/fruit/GetFruitUseCaseTest.java
@@ -1,0 +1,65 @@
+package kr.jsh.ecommerce.application.fruit;
+
+import kr.jsh.ecommerce.domain.fruit.Fruit;
+import kr.jsh.ecommerce.domain.fruit.FruitService;
+import kr.jsh.ecommerce.interfaces.dto.fruit.FruitResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.mockito.MockitoAnnotations;
+
+class GetFruitsUseCaseTest {
+
+    @Mock
+    private FruitService fruitService;
+
+    @InjectMocks
+    private GetFruitsUseCase getFruitsUseCase;
+
+    GetFruitsUseCaseTest() {
+        MockitoAnnotations.openMocks(this); // @InjectMocks와 @Mock 초기화
+    }
+
+    @Test
+    void testGetFruits() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 9);
+        Fruit fruit1 = Fruit.builder()
+                .fruitId(1L)
+                .fruitName("사과")
+                .fruitStock(50)
+                .fruitPrice(1000)
+                .status("재고있음")
+                .build();
+        Fruit fruit2 = Fruit.builder()
+                .fruitId(2L)
+                .fruitName("바나나")
+                .fruitStock(30)
+                .fruitPrice(1500)
+                .status("재고있음")
+                .build();
+        Page<Fruit> fruitsPage = new PageImpl<>(List.of(fruit1, fruit2));
+        when(fruitService.getFruits(pageable)).thenReturn(fruitsPage);
+
+        // When
+        Page<FruitResponse> result = getFruitsUseCase.getFruits(pageable);
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent().get(0).fruitName()).isEqualTo("사과");
+        assertThat(result.getContent().get(1).fruitName()).isEqualTo("바나나");
+        verify(fruitService, times(1)).getFruits(pageable);
+    }
+}

--- a/src/test/java/kr/jsh/ecommerce/application/order/CreateOrderUseCaseTest.java
+++ b/src/test/java/kr/jsh/ecommerce/application/order/CreateOrderUseCaseTest.java
@@ -1,0 +1,122 @@
+package kr.jsh.ecommerce.application.order;
+
+import kr.jsh.ecommerce.base.dto.BaseErrorCode;
+import kr.jsh.ecommerce.base.exception.BaseCustomException;
+import kr.jsh.ecommerce.domain.customer.Customer;
+import kr.jsh.ecommerce.domain.customer.CustomerService;
+import kr.jsh.ecommerce.domain.fruit.Fruit;
+import kr.jsh.ecommerce.domain.fruit.FruitService;
+import kr.jsh.ecommerce.domain.order.Order;
+import kr.jsh.ecommerce.domain.order.OrderFruit;
+import kr.jsh.ecommerce.domain.order.OrderService;
+import kr.jsh.ecommerce.interfaces.dto.order.OrderCreateResponse;
+import kr.jsh.ecommerce.interfaces.dto.order.OrderFruitRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateOrderUseCaseTest {
+
+    @Mock
+    private OrderService orderService;
+    @Mock
+    private CustomerService customerService;
+
+    @InjectMocks
+    private CreateOrderUseCase createOrderUseCase;
+
+    @Test
+    @DisplayName("정상적으로 주문을 생성한다.")
+    void createOrder_Success() {
+        // Given
+        String customerId = "1";
+        List<OrderFruitRequest> orderFruitRequests = List.of(
+                new OrderFruitRequest("1", "사과", 1000, 2),
+                new OrderFruitRequest("2", "바나나", 500, 3)
+        );
+
+        Customer customer = new Customer(1L, "황지수", "서울시 관악구 문성로", "010-1234-5678", null);
+
+        Order order = Order.builder()
+                .customer(customer)
+                .orderDate(LocalDateTime.now())
+                .orderStatus("결제전")
+                .orderFruits(new ArrayList<>())
+                .build();
+
+        OrderFruit orderFruit1 = new OrderFruit(order, customer,
+                Fruit.builder()
+                        .fruitId(1L)
+                        .fruitName("사과")
+                        .fruitStock(10)
+                        .fruitPrice(1000)
+                        .status("재고있음")
+                        .build(),
+                1000, 2);
+        OrderFruit orderFruit2 = new OrderFruit(order, customer,
+                Fruit.builder()
+                        .fruitId(2L)
+                        .fruitName("바나나")
+                        .fruitStock(20)
+                        .fruitPrice(500)
+                        .status("재고있음")
+                        .build(),
+                500, 3);
+
+        order.addOrderFruit(orderFruit1);
+        order.addOrderFruit(orderFruit2);
+        order.calculateTotalAmount(); // 총 금액 계산
+
+        OrderCreateResponse expectedResponse = OrderCreateResponse.fromOrder(order);
+
+        // When
+        when(customerService.getCustomerById(1L)).thenReturn(customer);
+        when(orderService.createOrder(customer)).thenReturn(order);
+        when(orderService.saveOrder(order, orderFruitRequests)).thenReturn(expectedResponse);
+
+        // Act
+        OrderCreateResponse result = createOrderUseCase.createOrder(customerId, orderFruitRequests);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.orderId()).isEqualTo("1");
+        assertThat(result.totalAmount()).isEqualTo(3500);
+
+        verify(customerService).getCustomerById(1L);
+        verify(orderService).createOrder(customer);
+        verify(orderService).saveOrder(order, orderFruitRequests);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 고객 ID로 주문 생성 시 예외를 던진다.")
+    void createOrder_CustomerNotFound() {
+        // Given
+        String customerId = "999";
+        List<OrderFruitRequest> orderFruitRequests = List.of(
+                new OrderFruitRequest("1", "사과", 1000, 2)
+        );
+
+        when(customerService.getCustomerById(999L))
+                .thenThrow(new BaseCustomException(BaseErrorCode.NOT_FOUND, new String[]{customerId}));
+
+        // When & Then
+        assertThatThrownBy(() -> createOrderUseCase.createOrder(customerId, orderFruitRequests))
+                .isInstanceOf(BaseCustomException.class)
+                .hasMessageContaining(BaseErrorCode.NOT_FOUND.getMessage());
+
+        verify(customerService).getCustomerById(999L);
+        verifyNoInteractions(orderService);
+    }
+}

--- a/src/test/java/kr/jsh/ecommerce/domain/fruit/FruitServiceTest.java
+++ b/src/test/java/kr/jsh/ecommerce/domain/fruit/FruitServiceTest.java
@@ -1,24 +1,92 @@
 package kr.jsh.ecommerce.domain.fruit;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
+import kr.jsh.ecommerce.infrastructure.fruit.FruitRepositoryImpl;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
-import static org.mockito.Mockito.mock;
+import java.util.List;
+import java.util.Optional;
 
-@ExtendWith(MockitoExtension.class)
-public class FruitServiceTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
+class FruitServiceTest {
+
+    @Mock
+    private FruitRepositoryImpl fruitRepositoryImpl;
+
+    @InjectMocks
     private FruitService fruitService;
-    private FruitRepository fruitRepository;
 
-    private Fruit fruitA;
-    private Fruit fruitB;
-
-    @BeforeEach
-    void setUp(){
-        fruitRepository = mock(FruitRepository.class);
-
+    FruitServiceTest() {
+        MockitoAnnotations.openMocks(this);
     }
 
+    @Test
+    void testGetFruits() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 9);
+        Fruit fruit1 = Fruit.builder()
+                .fruitId(1L)
+                .fruitName("딸기")
+                .fruitStock(50)
+                .fruitPrice(1000)
+                .status("재고있음")
+                .build();
+        Fruit fruit2 = Fruit.builder()
+                .fruitId(2L)
+                .fruitName("바나나")
+                .fruitStock(30)
+                .fruitPrice(1500)
+                .status("재고있음")
+                .build();
+        Page<Fruit> fruitsPage = new PageImpl<>(List.of(fruit1, fruit2));
+        when(fruitRepositoryImpl.findAll(pageable)).thenReturn(fruitsPage);
+
+        // When
+        Page<Fruit> result = fruitService.getFruits(pageable);
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent().get(0).getFruitName()).isEqualTo("딸기");
+        assertThat(result.getContent().get(1).getFruitName()).isEqualTo("바나나");
+        verify(fruitRepositoryImpl, times(1)).findAll(pageable);
+    }
+
+    @Test
+    void testGetFruitById_found() {
+        // Given
+        Fruit fruit = Fruit.builder()
+                .fruitId(1L)
+                .fruitName("딸기")
+                .fruitStock(50)
+                .fruitPrice(1000)
+                .status("재고있음")
+                .build();
+        when(fruitRepositoryImpl.findById(1L)).thenReturn(Optional.of(fruit));
+
+        // When
+        Fruit result = fruitService.getFruitById(1L);
+
+        // Then
+        assertThat(result.getFruitName()).isEqualTo("딸기");
+        verify(fruitRepositoryImpl, times(1)).findById(1L);
+    }
+
+    @Test
+    void testGetFruitById_notFound() {
+        // Given
+        when(fruitRepositoryImpl.findById(1L)).thenReturn(Optional.empty());
+
+        // When / Then
+        assertThrows(RuntimeException.class, () -> fruitService.getFruitById(1L));
+        verify(fruitRepositoryImpl, times(1)).findById(1L);
+    }
 }

--- a/src/test/java/kr/jsh/ecommerce/infrastructure/fruit/FruitRepositoryImplTest.java
+++ b/src/test/java/kr/jsh/ecommerce/infrastructure/fruit/FruitRepositoryImplTest.java
@@ -1,0 +1,96 @@
+package kr.jsh.ecommerce.infrastructure.fruit;
+
+import kr.jsh.ecommerce.domain.fruit.Fruit;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class FruitRepositoryImplTest {
+
+    @Mock
+    private FruitJpaRepository fruitJpaRepository;
+
+    @InjectMocks
+    private FruitRepositoryImpl fruitRepository;
+
+    FruitRepositoryImplTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testFindAll() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 9);
+        Fruit fruit1 = Fruit.builder()
+                .fruitId(1L)
+                .fruitName("망고스틴")
+                .fruitStock(50)
+                .fruitPrice(10000)
+                .status("AVAILABLE")
+                .build();
+        Fruit fruit2 = Fruit.builder()
+                .fruitId(2L)
+                .fruitName("파인애플")
+                .fruitStock(30)
+                .fruitPrice(15000)
+                .status("AVAILABLE")
+                .build();
+        Page<Fruit> fruitsPage = new PageImpl<>(List.of(fruit1, fruit2));
+        when(fruitJpaRepository.findAll(pageable)).thenReturn(fruitsPage);
+
+        // When
+        Page<Fruit> result = fruitRepository.findAll(pageable);
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent().get(0).getFruitName()).isEqualTo("망고스틴");
+        assertThat(result.getContent().get(1).getFruitName()).isEqualTo("파인애플");
+        verify(fruitJpaRepository, times(1)).findAll(pageable);
+    }
+
+    @Test
+    void testFindById_found() {
+        // Given
+        Fruit fruit = Fruit.builder()
+                .fruitId(1L)
+                .fruitName("망고스틴")
+                .fruitStock(50)
+                .fruitPrice(10000)
+                .status("AVAILABLE")
+                .build();
+        when(fruitJpaRepository.findById(1L)).thenReturn(Optional.of(fruit));
+
+        // When
+        Optional<Fruit> result = fruitRepository.findById(1L);
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get().getFruitName()).isEqualTo("망고스틴");
+        verify(fruitJpaRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void testFindById_notFound() {
+        // Given
+        when(fruitJpaRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // When
+        Optional<Fruit> result = fruitRepository.findById(1L);
+
+        // Then
+        assertThat(result).isEmpty();
+        verify(fruitJpaRepository, times(1)).findById(1L);
+    }
+}
+

--- a/src/test/java/kr/jsh/ecommerce/interfaces/fruit/FruitControllerIntegrationTest.java
+++ b/src/test/java/kr/jsh/ecommerce/interfaces/fruit/FruitControllerIntegrationTest.java
@@ -1,0 +1,85 @@
+package kr.jsh.ecommerce.interfaces.fruit;
+
+import kr.jsh.ecommerce.domain.fruit.Fruit;
+import kr.jsh.ecommerce.infrastructure.fruit.FruitJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ComponentScan(basePackages = {"kr.jsh.ecommerce"})
+@EnableJpaRepositories(basePackages = {"kr.jsh.ecommerce.infrastructure"})
+@EntityScan(basePackages = {"kr.jsh.ecommerce.domain"})
+class FruitControllerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private FruitJpaRepository fruitJpaRepository;
+
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+
+        // 테스트 데이터 초기화
+        fruitJpaRepository.deleteAll(); // 기존 데이터 삭제
+
+        Fruit fruit1 = Fruit.builder()
+                .fruitName("사과")
+                .fruitStock(50)
+                .fruitPrice(1000)
+                .status("AVAILABLE")
+                .build();
+        Fruit fruit2 = Fruit.builder()
+                .fruitName("바나나")
+                .fruitStock(30)
+                .fruitPrice(1500)
+                .status("AVAILABLE")
+                .build();
+
+        fruitJpaRepository.saveAll(List.of(fruit1, fruit2));
+    }
+
+    @Test
+    void testGetFruits() {
+        // Given
+        String url = "http://localhost:" + port + "/api/items?page=0&size=9";
+
+        // When
+        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("사과", "바나나");
+    }
+
+    @Test
+    void testFindFruitById() {
+        // Given
+        Long fruitId = fruitJpaRepository.findAll().get(0).getFruitId();
+        String url = "http://localhost:" + port + "/api/items/" + fruitId;
+
+        // When
+        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("Apple");
+    }
+}
+


### PR DESCRIPTION
<!--
[STEP-9] 로깅, interceptor 
-->

## PR 설명
상품조회 기능 로깅을 위한 Interceptor 및 WebConfig : 741c20bd31eaa94f0ec6c1d30259dcac5433ded0

## 리뷰 포인트
- 현재 addPathPatterns("/api/items/**")로 경로를 지정했고, 제외할 경로는 없어 excludePathPatterns는 사용하지 않았습니다.
나중에 추가 경로나 제외 경로가 많아질 경우, addPathPatterns와 excludePathPatterns 관리가 복잡해질 수 있을 것 같습니다. 이를 더 효율적으로 관리할 방법이 있을까요?
- 현재 로그에는 요청 URI, HTTP 메서드, 처리 시간을 포함하도록 구현했습니다.
추가적으로 클라이언트 IP, 응답 상태 코드 등을 포함하는 것이 일반적일까요? 지금의 로깅이 적절한지 궁금합니다.
-LoggingInterceptor에서 요청과 응답 로깅을 모두 처리했는데, 이를 별도의 Filter나 다른 클래스에 분리하는 것이 더 적합할까요?
현재처럼 인터셉터에서 모든 로깅을 처리하는 방식이 유지보수나 성능 면에서 문제가 될 여지가 있을까요?
- 현재는 간단한 수동 테스트(경로에 요청 후 콘솔 로그 확인)로 검증했지만, 인터셉터의 동작을 검증하는 테스트 코드를 추가해야 할까요?
추가한다면 MockMvc를 사용한 테스트가 적절할지, 다른 방식이 있을지 궁금합니다.