### PR TITLE
step-16

### DIFF
--- a/src/main/java/kr/jsh/ecommerce/application/payment/PayForOrderUseCase.java
+++ b/src/main/java/kr/jsh/ecommerce/application/payment/PayForOrderUseCase.java
@@ -27,6 +27,7 @@ public class PayForOrderUseCase {
         }
         // 결제 생성
         Payment payment = paymentService.createPayment(order, issuedCoupon);
+
         return PaymentResponse.fromEntity(payment);
     }
 }

--- a/src/main/java/kr/jsh/ecommerce/config/AsyncConfig.java
+++ b/src/main/java/kr/jsh/ecommerce/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package kr.jsh.ecommerce.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/kr/jsh/ecommerce/domain/payment/DataPlatFormClient.java
+++ b/src/main/java/kr/jsh/ecommerce/domain/payment/DataPlatFormClient.java
@@ -1,0 +1,5 @@
+package kr.jsh.ecommerce.domain.payment;
+
+public interface DataPlatFormClient {
+    void sendOrderData(OrderData orderData);
+}

--- a/src/main/java/kr/jsh/ecommerce/domain/payment/OrderData.java
+++ b/src/main/java/kr/jsh/ecommerce/domain/payment/OrderData.java
@@ -1,0 +1,20 @@
+package kr.jsh.ecommerce.domain.payment;
+
+import kr.jsh.ecommerce.domain.order.Order;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderData {
+    private final Long orderId;
+    private final LocalDateTime orderDate;
+    private final int totalAmount;
+
+    public static OrderData from(final Order order){
+        return new OrderData(order.getOrderId(),order.getOrderDate(),order.getTotalAmount());
+    }
+}

--- a/src/main/java/kr/jsh/ecommerce/domain/payment/PaymentService.java
+++ b/src/main/java/kr/jsh/ecommerce/domain/payment/PaymentService.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final OrderRepository orderRepository;
+    private final DataPlatFormClient dataPlatFormClient;
 
     @Transactional
     public Payment createPayment(Order order, CouponIssue issuedCoupon) {
@@ -43,6 +44,8 @@ public class PaymentService {
             // 예외 발생 시 결제 실패 처리
             payment.failPayment();
         }
+
+        dataPlatFormClient.sendOrderData(OrderData.from(order));
 
         //결제 정보 저장
         paymentRepository.save(payment);

--- a/src/main/java/kr/jsh/ecommerce/domain/payment/PaymentService.java
+++ b/src/main/java/kr/jsh/ecommerce/domain/payment/PaymentService.java
@@ -7,7 +7,9 @@ import kr.jsh.ecommerce.domain.order.OrderRepository;
 import kr.jsh.ecommerce.domain.payment.Payment;
 import kr.jsh.ecommerce.domain.payment.PaymentRepository;
 import kr.jsh.ecommerce.domain.wallet.Wallet;
+import kr.jsh.ecommerce.event.OrderPaidEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,15 +20,64 @@ import java.time.LocalDateTime;
 public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final OrderRepository orderRepository;
-    private final DataPlatFormClient dataPlatFormClient;
+    private final ApplicationEventPublisher eventPublisher;
 
+    @Transactional
+    public Payment createPayment(Order order, CouponIssue issuedCoupon) {
+        Payment payment = decreaseBalance(order, issuedCoupon);
+        Order updatedOrder = updateOrderStatus(order, payment);
+        paymentRepository.save(payment);
+        orderRepository.save(updatedOrder);
+
+        //주문 결제 완료 이벤트 발행
+        if (payment.getPaymentStatus() == PaymentStatus.SUCCESS) {
+            eventPublisher.publishEvent(new OrderPaidEvent(this, order));
+        }
+        return payment;
+    }
+
+    @Transactional
+    public Payment decreaseBalance(Order order, CouponIssue issuedCoupon) {
+        Wallet wallet = order.getCustomer().getWallet();
+        // 쿠폰 할인 적용
+        int discount = 0;
+        if (issuedCoupon != null) {
+            issuedCoupon.markAsUsed();  // 쿠폰 사용 처리
+            discount = issuedCoupon.getCoupon().getDiscountAmount();
+        }
+        // 최종 결제 금액 계산
+        int finalAmount = Math.max(0, order.getTotalAmount() - discount);
+
+        //결제 객체 생성
+        Payment payment = Payment.create(order, finalAmount);
+
+        //잔액 차감
+        try {
+            // 결제 시도
+            wallet.spendCash(finalAmount);
+            payment.completePayment();
+        } catch (BaseCustomException e) {
+            // 예외 발생 시 결제 실패 처리
+            payment.failPayment();
+        }
+
+        return payment;
+    }
+
+    public Order updateOrderStatus(Order order, Payment payment) {
+        order.setPayment(payment);
+        return order;
+    }
+
+
+/*
     @Transactional
     public Payment createPayment(Order order, CouponIssue issuedCoupon) {
         Wallet wallet = order.getCustomer().getWallet();
         // 쿠폰 할인 적용
         int discount = 0;
         if (issuedCoupon != null) {
-            issuedCoupon.markAsUsed();  // ✅ 쿠폰 사용 처리
+            issuedCoupon.markAsUsed();  // 쿠폰 사용 처리
             discount = issuedCoupon.getCoupon().getDiscountAmount();
         }
         // 최종 결제 금액 계산
@@ -54,4 +105,5 @@ public class PaymentService {
 
         return payment;
     }
+ */
 }

--- a/src/main/java/kr/jsh/ecommerce/domain/wallet/Wallet.java
+++ b/src/main/java/kr/jsh/ecommerce/domain/wallet/Wallet.java
@@ -40,7 +40,7 @@ public class Wallet {
 
     public void spendCash(int amount) {
         if (amount > this.balance||amount%100!=0) {
-            throw new BaseCustomException(BaseErrorCode.INVALID_PARAMETER, new String[]{String.valueOf(amount)});
+            throw new BaseCustomException(BaseErrorCode.INSUFFICIENT_BALANCE, new String[]{String.valueOf(amount)});
         }
         this.balance -= amount;
     }

--- a/src/main/java/kr/jsh/ecommerce/event/OrderPaidEvent.java
+++ b/src/main/java/kr/jsh/ecommerce/event/OrderPaidEvent.java
@@ -1,0 +1,18 @@
+package kr.jsh.ecommerce.event;
+
+import kr.jsh.ecommerce.domain.order.Order;
+import org.springframework.context.ApplicationEvent;
+
+public class OrderPaidEvent extends ApplicationEvent {
+
+    private final Order order;
+
+    public OrderPaidEvent(Object source, Order order){
+        super(source);
+        this.order = order;
+    }
+
+    public Order getOrder(){
+        return order;
+    }
+}

--- a/src/main/java/kr/jsh/ecommerce/event/OrderPaidEventListener.java
+++ b/src/main/java/kr/jsh/ecommerce/event/OrderPaidEventListener.java
@@ -1,0 +1,30 @@
+package kr.jsh.ecommerce.event;
+
+import kr.jsh.ecommerce.domain.order.Order;
+import kr.jsh.ecommerce.domain.payment.DataPlatFormClient;
+import kr.jsh.ecommerce.domain.payment.OrderData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderPaidEventListener {
+    private final DataPlatFormClient dataPlatFormClient;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendOrderInfo(OrderPaidEvent event){
+      log.info("결제 완료 감지! 결제 완료된 주문 id:{}",event.getOrder().getOrderId());
+      sendOrderToExternalAPI(event.getOrder());
+    }
+
+    private void sendOrderToExternalAPI(Order order){
+        dataPlatFormClient.sendOrderData(OrderData.from(order));
+        log.info("외부 API로 주문 정보 전송 완료!");
+    }
+}

--- a/src/main/java/kr/jsh/ecommerce/infrastructure/payment/MockDataPlatformClient.java
+++ b/src/main/java/kr/jsh/ecommerce/infrastructure/payment/MockDataPlatformClient.java
@@ -1,0 +1,21 @@
+package kr.jsh.ecommerce.infrastructure.payment;
+
+import kr.jsh.ecommerce.domain.payment.DataPlatFormClient;
+import kr.jsh.ecommerce.domain.payment.OrderData;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class MockDataPlatformClient implements DataPlatFormClient {
+    @Async
+    @Override
+    public void sendOrderData(OrderData orderData) {
+        try{
+            log.info("주문 정보 전송. {}",orderData);
+        }catch (Exception e){
+            log.error("주문 정보 전송 실패. 주문아이디={}",orderData.getOrderId(),e);
+        }
+    }
+}

--- a/src/test/java/kr/jsh/ecommerce/domain/payment/OrderPaidEventListenerTest.java
+++ b/src/test/java/kr/jsh/ecommerce/domain/payment/OrderPaidEventListenerTest.java
@@ -1,0 +1,44 @@
+package kr.jsh.ecommerce.domain.payment;
+
+import kr.jsh.ecommerce.domain.order.Order;
+import kr.jsh.ecommerce.event.OrderPaidEvent;
+import kr.jsh.ecommerce.event.OrderPaidEventListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderPaidEventListenerTest {
+
+    @Mock
+    private DataPlatFormClient dataPlatFormClient;
+
+    @InjectMocks
+    private OrderPaidEventListener orderPaidEventListener;
+
+    private Order order;
+
+    @BeforeEach
+    void setUp(){
+        order = mock(Order.class);
+        when(order.getOrderId()).thenReturn(100L);
+    }
+
+    @Test
+    void sendOrderInfoAfterPayment(){
+        //given
+        OrderPaidEvent event = new OrderPaidEvent(this, order);
+
+        //when
+        orderPaidEventListener.sendOrderInfo(event);
+
+        //then
+        //외부 API가 한 번 호출되었는지 확인
+        verify(dataPlatFormClient,times(1)).sendOrderData(any(OrderData.class));
+    }
+}


### PR DESCRIPTION
## PR 설명
외부 데이터 플랫폼으로 주문데이터 송출 구현 :

https://github.com/JiSoo-Hwang/Week3_e-commerce/commit/e77c097d5a6dfb76ddfd381082ec7ab440998d5b

02/16일자 추가 커밋: 결제 완료 후 외부 API 호출하는 이벤트 발행
https://github.com/JiSoo-Hwang/Week3_e-commerce/pull/24/commits/1222c5148228b5941063841710dad6df742a37e0

## 리뷰 포인트
저는 이전에 아직 기능 구현을 완성하지를 못해서, 기존에 mock api호출부터 구현했습니다.
이번주의 요구사항대로의 구현은 좀 더 공부하고 구현해보도록 하겠습니다(강해져서 돌아올게요🥹)

02/16 일자 추가 리뷰 포인트 : 
처음 테스트를 돌려보니... 결제가 성공/실패 두 케이스 모두 이벤트가 그냥... 발행되어버리더라구요🙈
그래서 일단 if문으로 막아 봤습니다...🥹
이번주 과제에 결제가 실패했을 때 또 다른 이벤트 발행하고 보상로직 적용해보도록 하겠습니다.